### PR TITLE
Add Illegal Access Page

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,3 @@
 ## Solution
 
 ## Testing
-
-- [ ] Ready to Merge
-- [ ] Requires Changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Problem Statement
+
+## Solution
+
+## Testing
+
+- [ ] Ready to Merge
+- [ ] Requires Changes

--- a/services/illegal.php
+++ b/services/illegal.php
@@ -1,0 +1,8 @@
+<h2 style="margin: 20px; margin-bottom:10px; font-family:Arial, Helvetica, sans-serif">
+    ⚠ Illegal Content Access Detected
+</h2>
+<h3
+    style="margin-left: 20px; margin-top:0px; font-family:Arial, Helvetica, sans-serif; font-weight:lighter; line-height: 28px;">
+    Unauthorized access to server files is strictly prohibited and illegal in many jurisdictions.<br>Any attempt to
+    connect and tamper with server files is considered theft.<br>All rights are reserved - GradePlus.
+</h3>


### PR DESCRIPTION
## Problem Statement
Need to show an illegal access detection page

## Solution
Show the following page when a microservice is accessed illegally, that is, without the correct POST authorization secret of `gradeplus`

## Testing
Tested by calling `reset-demo.php` directly from URL in browser.<br>
![image](https://github.com/user-attachments/assets/39b8597c-df70-4376-86bd-9a03ec92d948)