### PR TITLE
De-enroll, Course Update, Delete Course Microservices

### DIFF
--- a/services/course-update.php
+++ b/services/course-update.php
@@ -1,0 +1,85 @@
+<?php
+
+header('Content-Type: application/json');
+
+// Start the session
+session_start();
+
+// Check if the authorization token is correct
+if ($_POST['authorize'] === 'gradeplus') {
+    $conn = null;
+    try {
+        // Connect to the MySQL database using prepared statements
+        $conn = new mysqli('localhost', 'gradeplusclient', 'gradeplussql', 'gradeplus');
+        if ($conn->connect_error) {
+            throw new Exception("Connection failed: " . $conn->connect_error);
+        }
+
+        // Handle the banner image upload if provided
+        if (!empty($_FILES['banner'])) {
+            $img_dir = "../img/";
+            $banner_img = basename($_FILES['banner']['name']);
+            $upload_dir = $img_dir . $banner_img;
+
+            if (!move_uploaded_file($_POST['banner']['tmp_name'], $upload_dir)) {
+                throw new Exception("Failed to upload file to img directory");
+            }
+
+            // Update the course banner using a prepared statement
+            $stmt = $conn->prepare("UPDATE courses SET course_banner = ? WHERE invite_code = ?");
+            $stmt->bind_param("ss", $upload_dir, $_POST['invitecode']);
+            if (!$stmt->execute()) {
+                throw new Exception("Failed to update course banner: " . $conn->error);
+            }
+            $stmt->close();
+        }
+
+        // Update the course name using a prepared statement
+        if ($_POST['coursename'] != null) {
+            $stmt = $conn->prepare("UPDATE courses SET course_name = ? WHERE invite_code = ?");
+            $stmt->bind_param("ss", $_POST['coursename'], $_POST['invitecode']);
+            if (!$stmt->execute()) {
+                throw new Exception("Failed to update course name: " . $conn->error);
+            }
+            $stmt->close();
+            $stmt = $conn->prepare("UPDATE enrollment SET course_name = ? WHERE invite_code = ?");
+            $stmt->bind_param("ss", $_POST['coursename'], $_POST['invitecode']);
+            if (!$stmt->execute()) {
+                throw new Exception("Failed to update course name: " . $conn->error);
+            }
+        }
+
+        // Update the course code using a prepared statement
+        if ($_POST['coursecode'] != null) {
+            $stmt = $conn->prepare("UPDATE courses SET course_code = ? WHERE invite_code = ?");
+            $stmt->bind_param("ss", $_POST['coursecode'], $_POST['invitecode']);
+            if (!$stmt->execute()) {
+                throw new Exception("Failed to update course name: " . $conn->error);
+            }
+            $stmt->close();
+            $stmt = $conn->prepare("UPDATE enrollment SET course_code = ? WHERE invite_code = ?");
+            $stmt->bind_param("ss", $_POST['coursecode'], $_POST['invitecode']);
+            if (!$stmt->execute()) {
+                throw new Exception("Failed to update course name: " . $conn->error);
+            }
+            $stmt->close();
+        }
+
+        // Close the connection
+        $conn->close();
+
+        // Return success response
+        echo json_encode(['success' => 1, 'error' => 0]);
+    } catch (Exception $e) {
+        // Close the connection if it exists
+        if ($conn) {
+            $conn->close();
+        }
+
+        // Return error response with a message for debugging
+        echo json_encode(['success' => 0, 'error' => 1]);
+    }
+} else {
+    // Redirect to the illegal access page
+    header("Location: illegal.php");
+}

--- a/services/de-enroll-user.php
+++ b/services/de-enroll-user.php
@@ -1,0 +1,45 @@
+<?php
+
+header('Content-Type: application/json');
+
+// Start the session
+session_start();
+
+// Check if the authorization token is correct
+if ($_POST['authorize'] === 'gradeplus') {
+    $conn = null;
+    try {
+        // Connect to the MySQL database using prepared statements
+        $conn = new mysqli('localhost', 'gradeplusclient', 'gradeplussql', 'gradeplus');
+        if ($conn->connect_error) {
+            throw new Exception("Connection failed: " . $conn->connect_error);
+        }
+
+        // Update the course code using a prepared statement
+        if ($_POST['invitecode'] != null) {
+            $stmt = $conn->prepare("DELETE FROM enrollment WHERE invite_code = ? AND username = ?");
+            $stmt->bind_param("ss", $_POST['invitecode'], $_POST['username']);
+            if (!$stmt->execute()) {
+                throw new Exception("Failed to update course name: " . $conn->error);
+            }
+            $stmt->close();
+        }
+
+        // Close the connection
+        $conn->close();
+
+        // Return success response
+        echo json_encode(['success' => 1, 'error' => 0]);
+    } catch (Exception $e) {
+        // Close the connection if it exists
+        if ($conn) {
+            $conn->close();
+        }
+
+        // Return error response with a message for debugging
+        echo json_encode(['success' => 0, 'error' => 1]);
+    }
+} else {
+    // Redirect to the illegal access page
+    header("Location: illegal.php");
+}

--- a/services/delete-course.php
+++ b/services/delete-course.php
@@ -1,0 +1,51 @@
+<?php
+
+header('Content-Type: application/json');
+
+// Start the session
+session_start();
+
+// Check if the authorization token is correct
+if ($_POST['authorize'] === 'gradeplus') {
+    $conn = null;
+    try {
+        // Connect to the MySQL database using prepared statements
+        $conn = new mysqli('localhost', 'gradeplusclient', 'gradeplussql', 'gradeplus');
+        if ($conn->connect_error) {
+            throw new Exception("Connection failed: " . $conn->connect_error);
+        }
+
+        // Update the course code using a prepared statement
+        if ($_POST['invitecode'] != null) {
+            $stmt = $conn->prepare("DELETE FROM courses WHERE invite_code = ?");
+            $stmt->bind_param("s", $_POST['invitecode']);
+            if (!$stmt->execute()) {
+                throw new Exception("Failed to update course name: " . $conn->error);
+            }
+            $stmt->close();
+            $stmt = $conn->prepare("DELETE FROM enrollment WHERE invite_code = ?");
+            $stmt->bind_param("s", $_POST['invitecode']);
+            if (!$stmt->execute()) {
+                throw new Exception("Failed to update course name: " . $conn->error);
+            }
+            $stmt->close();
+        }
+
+        // Close the connection
+        $conn->close();
+
+        // Return success response
+        echo json_encode(['success' => 1, 'error' => 0]);
+    } catch (Exception $e) {
+        // Close the connection if it exists
+        if ($conn) {
+            $conn->close();
+        }
+
+        // Return error response with a message for debugging
+        echo json_encode(['success' => 0, 'error' => 1]);
+    }
+} else {
+    // Redirect to the illegal access page
+    header("Location: illegal.php");
+}


### PR DESCRIPTION
UPDATE: This PHP code checks authorization, connects to a MySQL database, and updates course details (name, code, and banner) using prepared statements. It securely uploads a banner if provided, handles errors with try-catch, and responds with JSON. If authorization fails, it redirects to an illegal access page

DELETE: This PHP code checks authorization and, if valid, connects to a MySQL database to delete course and enrollment records by invite_code using prepared statements. It handles errors with try-catch, closes the connection, and returns a JSON response. Unauthorized access redirects to an illegal access page.

De-Enroll: This PHP code checks authorization and connects to a MySQL database to delete a specific user’s enrollment record based on invite_code and username using prepared statements. It handles errors with try-catch, closes the connection, and returns a JSON response. Unauthorized access triggers a redirect to an illegal access page.